### PR TITLE
Bump/cli 0.6.1 beta.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY entrypoint.sh /stark_ga/entrypoint.sh
 COPY dist /stark_ga/dist
 
 # Install stark accessibility cli
-RUN npm i -g @stark-lab-inc/accessibility-cli@0.6.0-beta.1 \
+RUN npm i -g @stark-lab-inc/accessibility-cli@0.6.1-beta.0 \
     && stark-accessibility --version
 
 # TODO: symlink /root/.local-chromium to $GITHUB_HOME/.local-chromium to avoid double install or remove install from this step.

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "eslint-plugin-prettier": "^5.0.1",
         "jest": "^29.7.0",
         "js-yaml": "^4.1.0",
-        "prettier": "^3.2.2",
+        "prettier": "^3.2.4",
         "ts-jest": "^29.1.2",
         "typescript": "^5.3.3"
       }
@@ -6455,9 +6455,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.2.tgz",
-      "integrity": "sha512-HTByuKZzw7utPiDO523Tt2pLtEyK7OibUD9suEJQrPUCYQqrHr74GGX6VidMrovbf/I50mPqr8j/II6oBAuc5A==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.4.tgz",
+      "integrity": "sha512-FWu1oLHKCrtpO1ypU6J0SbK2d9Ckwysq6bHj/uaCP26DxrPpppCLQRGVuqAxSTvhF00AcvDRyYrLNW7ocBhFFQ==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -12311,9 +12311,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.2.tgz",
-      "integrity": "sha512-HTByuKZzw7utPiDO523Tt2pLtEyK7OibUD9suEJQrPUCYQqrHr74GGX6VidMrovbf/I50mPqr8j/II6oBAuc5A==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.4.tgz",
+      "integrity": "sha512-FWu1oLHKCrtpO1ypU6J0SbK2d9Ckwysq6bHj/uaCP26DxrPpppCLQRGVuqAxSTvhF00AcvDRyYrLNW7ocBhFFQ==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "eslint-plugin-prettier": "^5.0.1",
     "jest": "^29.7.0",
     "js-yaml": "^4.1.0",
-    "prettier": "^3.2.2",
+    "prettier": "^3.2.4",
     "ts-jest": "^29.1.2",
     "typescript": "^5.3.3"
   }


### PR DESCRIPTION
Uses cli 0.6.1-beta.0
- rule-engine updated to 0.6.0 - additional checks and bug fixes
- update developer dependencies