### PR TITLE
bump version and cli version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY entrypoint.sh /stark_ga/entrypoint.sh
 COPY dist /stark_ga/dist
 
 # Install stark accessibility cli
-RUN npm i -g @stark-lab-inc/accessibility-cli@0.6.1-beta.0 \
+RUN npm i -g @stark-lab-inc/accessibility-cli@0.6.2-beta.0 \
     && stark-accessibility --version
 
 # TODO: symlink /root/.local-chromium to $GITHUB_HOME/.local-chromium to avoid double install or remove install from this step.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "accessibility-check-action",
-  "version": "0.6.0-beta.1",
+  "version": "0.6.2-beta.0",
   "private": true,
   "description": "Stark action to run accessibility in github actions",
   "main": "lib/main.js",


### PR DESCRIPTION
- Bumps cli to 0.6.2-beta.0
-- conformance levels in scan results (A, AA, AAA)
- Updates node types