### PR TITLE
Bump cli to 0.7.0-beta.0

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set Node.js 16.x
-        uses: actions/setup-node@v4.0.1
+        uses: actions/setup-node@v4.0.2
         with:
           node-version: 16.x
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY entrypoint.sh /stark_ga/entrypoint.sh
 COPY dist /stark_ga/dist
 
 # Install stark accessibility cli
-RUN npm i -g @stark-lab-inc/accessibility-cli@0.6.2-beta.0 \
+RUN npm i -g @stark-lab-inc/accessibility-cli@0.7.0-beta.0 \
     && stark-accessibility --version
 
 # TODO: symlink /root/.local-chromium to $GITHUB_HOME/.local-chromium to avoid double install or remove install from this step.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "accessibility-check-action",
-  "version": "0.6.0-beta.1",
+  "version": "0.6.2-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "accessibility-check-action",
-      "version": "0.6.0-beta.1",
+      "version": "0.6.2-beta.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.1",
@@ -17,12 +17,12 @@
       },
       "devDependencies": {
         "@types/lodash": "^4.14.201",
-        "@types/node": "^20.11.10",
+        "@types/node": "^20.11.19",
         "@typescript-eslint/parser": "^5.59.2",
         "@vercel/ncc": "^0.38.1",
         "eslint": "^8.56.0",
         "eslint-plugin-github": "^4.10.1",
-        "eslint-plugin-jest": "^27.6.3",
+        "eslint-plugin-jest": "^27.9.0",
         "eslint-plugin-prettier": "^5.0.1",
         "jest": "^29.7.0",
         "js-yaml": "^4.1.0",
@@ -1647,9 +1647,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.11.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.10.tgz",
-      "integrity": "sha512-rZEfe/hJSGYmdfX9tvcPMYeYPW2sNl50nsw4jZmRcaG0HIAb0WYEpsB05GOb53vjqpyE9GUhlDQ4jLSoB5q9kg==",
+      "version": "20.11.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.19.tgz",
+      "integrity": "sha512-7xMnVEcZFu0DikYjWOlRq7NTPETrm7teqUT2WkQjrTIkEgUyyGdWsj/Zg8bEJt5TNklzbPD1X3fqfsHw3SpapQ==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -3597,9 +3597,9 @@
       "dev": true
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "27.6.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.6.3.tgz",
-      "integrity": "sha512-+YsJFVH6R+tOiO3gCJon5oqn4KWc+mDq2leudk8mrp8RFubLOo9CVyi3cib4L7XMpxExmkmBZQTPDYVBzgpgOA==",
+      "version": "27.9.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.9.0.tgz",
+      "integrity": "sha512-QIT7FH7fNmd9n4se7FFKHbsLKGQiw885Ds6Y/sxKgCZ6natwCsXdgPOADnYVxN2QrRweF0FZWbJ6S7Rsn7llug==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/utils": "^5.10.0"
@@ -3608,7 +3608,7 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       },
       "peerDependencies": {
-        "@typescript-eslint/eslint-plugin": "^5.0.0 || ^6.0.0",
+        "@typescript-eslint/eslint-plugin": "^5.0.0 || ^6.0.0 || ^7.0.0",
         "eslint": "^7.0.0 || ^8.0.0",
         "jest": "*"
       },
@@ -8897,9 +8897,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "20.11.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.10.tgz",
-      "integrity": "sha512-rZEfe/hJSGYmdfX9tvcPMYeYPW2sNl50nsw4jZmRcaG0HIAb0WYEpsB05GOb53vjqpyE9GUhlDQ4jLSoB5q9kg==",
+      "version": "20.11.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.19.tgz",
+      "integrity": "sha512-7xMnVEcZFu0DikYjWOlRq7NTPETrm7teqUT2WkQjrTIkEgUyyGdWsj/Zg8bEJt5TNklzbPD1X3fqfsHw3SpapQ==",
       "dev": true,
       "requires": {
         "undici-types": "~5.26.4"
@@ -10335,9 +10335,9 @@
       }
     },
     "eslint-plugin-jest": {
-      "version": "27.6.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.6.3.tgz",
-      "integrity": "sha512-+YsJFVH6R+tOiO3gCJon5oqn4KWc+mDq2leudk8mrp8RFubLOo9CVyi3cib4L7XMpxExmkmBZQTPDYVBzgpgOA==",
+      "version": "27.9.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.9.0.tgz",
+      "integrity": "sha512-QIT7FH7fNmd9n4se7FFKHbsLKGQiw885Ds6Y/sxKgCZ6natwCsXdgPOADnYVxN2QrRweF0FZWbJ6S7Rsn7llug==",
       "dev": true,
       "requires": {
         "@typescript-eslint/utils": "^5.10.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "accessibility-check-action",
-  "version": "0.6.2-beta.0",
+  "version": "0.7.0-beta.0",
   "private": true,
   "description": "Stark action to run accessibility in github actions",
   "main": "lib/main.js",
@@ -34,12 +34,12 @@
   },
   "devDependencies": {
     "@types/lodash": "^4.14.201",
-    "@types/node": "^20.11.10",
+    "@types/node": "^20.11.19",
     "@typescript-eslint/parser": "^5.59.2",
     "@vercel/ncc": "^0.38.1",
     "eslint": "^8.56.0",
     "eslint-plugin-github": "^4.10.1",
-    "eslint-plugin-jest": "^27.6.3",
+    "eslint-plugin-jest": "^27.9.0",
     "eslint-plugin-prettier": "^5.0.1",
     "jest": "^29.7.0",
     "js-yaml": "^4.1.0",


### PR DESCRIPTION
Updates cli to 0.7.0-beta.0
- puppeteer updated to latest (fixes unable to download browser bug)
- cli sets base node engine to 18 from 16
- dependabot updates